### PR TITLE
Fixed 3 parameter types

### DIFF
--- a/N/search.d.ts
+++ b/N/search.d.ts
@@ -22,7 +22,7 @@ interface SearchColumnSetWhenOrderedByOptions {
 /** Encapsulates a single search column in a search.Search. Use the methods and properties available to the Column object to get or set Column properties. */
 export interface Column {
     /** Returns the search column for which the minimal or maximal value should be found when returning the search.Column value. */
-    setWhenOrderedBy?(SearchColumnSetWhenOrderedByOptions): Column;
+    setWhenOrderedBy?(options: SearchColumnSetWhenOrderedByOptions): Column;
     /** Name of a search column as a string. */
     name: string;
     /** Join ID for a search column as a string. */
@@ -47,9 +47,9 @@ interface SearchResultGetValueTextOptions {
 
 export interface Result {
     getValue(options: SearchResultGetValueTextOptions): boolean | string | string[];
-    getValue(SearchColumn): boolean | string | string[];
+    getValue(column: SearchColumn): boolean | string | string[];
     getText(options: SearchResultGetValueTextOptions): string;
-    getText(SearchColumn): string;
+    getValue(column: SearchColumn): string;
     recordType: Type | string;
     id: string;
     columns: Column[];


### PR DESCRIPTION
Column.setWhenOrderedBy(...), Result.getValue(...), and .getText(...) implicitly got an "any" parameter because you missed the argument name. Fixed that here.