### PR TITLE
Fixed ConfigGetOptions type definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 typings
 .idea
+.DS_Store

--- a/N/config.d.ts
+++ b/N/config.d.ts
@@ -1,15 +1,15 @@
 interface ConfigSetValueOptions {
-    name: string;
-    text: (string | string[]);
+    fieldId: string;
+    value: (string | string[] | boolean | number);
 }
 
 interface ConfigSetTextOptions {
-    name: string;
+    fieldId: string;
     text: (string | string[]);
 }
 
 interface ConfigGetOptions {
-    name: string;
+    fieldId: string;
 }
 
 interface Config {


### PR DESCRIPTION
Fixed some of the type definitions with the Config module (i.e. name => fieldID). This is related to issue #43.