### PR TITLE
explicitly add `null` to FieldValue type

### DIFF
--- a/N/record.d.ts
+++ b/N/record.d.ts
@@ -326,7 +326,7 @@ export interface Field {
     isReadOnly: boolean;
 }
 
-type FieldValue = Date | number | number[] | string | string[] | boolean;
+type FieldValue = Date | number | number[] | string | string[] | boolean | null;
 
 /** Almost like a full Record, except without things like save(). */
 export interface ClientCurrentRecord {


### PR DESCRIPTION
so as to be compatible with --strictNullChecks compiler option. Setting a field value to null 'clears' it in the NS database.