### PR TITLE
The original docs listed url.format options as "domain" and "paramete…

### DIFF
--- a/N/url.d.ts
+++ b/N/url.d.ts
@@ -1,6 +1,6 @@
 interface formatOptions {
     domain: string;
-    parameters: any;
+    params: any;
 }
 
 interface resolveHostOptions {


### PR DESCRIPTION
…rs" but they have since been updated to "domain" and "params". I tested this recently and "params" works, while "parameters" does not.