### PR TITLE
N/search is missing Type for search.load

### DIFF
--- a/N/search.d.ts
+++ b/N/search.d.ts
@@ -253,7 +253,7 @@ interface SearchLoadOptions {
      * - InvtNumberItemBalance
      * - ItemBinNumber
      */
-    type?: string;
+    type?: string | Type;
 }
 
 interface SearchLoadFunction {


### PR DESCRIPTION
N/search can't use the enum functionality provided by NetSuite since search.Type is its own enum and type expects a string.