### PR TITLE
Record get/set sublist should accept FieldValue for line argument

### DIFF
--- a/N/record.d.ts
+++ b/N/record.d.ts
@@ -125,7 +125,7 @@ interface GetSublistValueOptions {
     /** The internal ID of a standard or custom sublist field. */
     fieldId: string;
     /** The line number for the field. */
-    line: number;
+    line: FieldValue | number;
 }
 
 interface GetCurrentSublistFieldOptions {
@@ -283,7 +283,7 @@ interface SetSublistValueOptions {
     /** The internal ID of a standard or custom sublist field. */
     fieldId: string;
     /** The internal ID of a standard or custom sublist field. */
-    line: number;
+    line: FieldValue | number;
     /**
      * The value to set the sublist field to.
      * The value type must correspond to the field type being set. For example:


### PR DESCRIPTION
This one may be a bit controversial, similar to my previous commit wherein loading a record with `record.load` passing a FieldValue as the `id` is acceptable.

When calling `getSublistValue`/`setSublistValue`, the `line` number could be the result of reading a FieldValue from a previous call. The best example is when looking at a parent `orderline` from a child Receipt, RMA, Fulfillment, etc. where the value returned is an integer line number.