### PR TITLE
proposal: enhance search.lookupFields intellisense

### DIFF
--- a/N/search.d.ts
+++ b/N/search.d.ts
@@ -191,10 +191,22 @@ interface SearchLookupFieldsOptions {
     columns: (string | string[]);
 }
 
+type LookupValue = string | number | boolean | {value:string, text:string}[]
+
 interface SearchLookupFieldsFunction {
-    promise(options: SearchLookupFieldsOptions): Promise<any>;
-    (options: SearchLookupFieldsOptions): any;
+    promise<T extends string>(options: {
+		type: Type | string;
+		id: FieldValue | string | number;
+		columns: T | T[]
+	}): Promise<{ [ K in T ]?: LookupValue }>;
+	
+	<T extends string>(options: {
+		type: Type | string;
+		id: FieldValue | string | number;
+		columns: T | T[]
+	}): { [ K in T ]?: LookupValue };
 }
+
 /** Global search keywords string or expression. */
 interface SearchGlobalOptions {
     keywords: string;

--- a/N/search.d.ts
+++ b/N/search.d.ts
@@ -185,12 +185,6 @@ export interface CreateSearchColumnOptions {
     sort?: Sort;
 }
 
-interface SearchLookupFieldsOptions {
-    type: Type | string;
-    id: FieldValue | string | number;
-    columns: (string | string[]);
-}
-
 type LookupValue = string | number | boolean | {value:string, text:string}[]
 
 interface SearchLookupFieldsFunction {


### PR DESCRIPTION
I had been looking into TypeScript Generics some recently, figured this might be useful to others.
I am by no means a TS expert so please offer feedback if implementation can be improved.

Example with updated behavior:
![image](https://user-images.githubusercontent.com/66735423/97129069-594dfc80-1714-11eb-8b64-363d19f4909b.png)


I really wanted to have a reusable interface similar to `SearchLookupFieldsOptions` for the object structure of Generic itself, but I am not sure if this is possible in TS syntax?
Thanks