### PR TITLE
exporting CreateSearchFilterOptions

### DIFF
--- a/N/search.d.ts
+++ b/N/search.d.ts
@@ -160,7 +160,7 @@ export interface Search {
     runPaged: SearchRunPagedFunction;
 }
 
-interface CreateSearchFilterOptions {
+export interface CreateSearchFilterOptions {
     /** Name or internal ID of the search field. */
     name: string;
     /** Join ID for the search filter. */


### PR DESCRIPTION
So it can be used like:

```
const filters: NSearch.CreateSearchFilterOptions[] = [
            {
                name: "name",
                operator: NSearch.Operator.ANYOF,
                values: "value",
            },
        ]

NSearch.create({
            type: "type",
            filters,
            columns,
        }).run()
```