### PR TITLE
lookup value object

### DIFF
--- a/N/search.d.ts
+++ b/N/search.d.ts
@@ -185,7 +185,9 @@ export interface CreateSearchColumnOptions {
     sort?: Sort;
 }
 
-type LookupValue = string | number | boolean | { value: string, text: string }[];
+type LookupValue = string | number | boolean | LookupValueObject[];
+
+export interface LookupValueObject { value: string, text: string }
 
 interface SearchLookupFieldsFunction {
     promise<T extends string>(options: {


### PR DESCRIPTION
This PR expose interface to be used in type assertions, as TS struggle to infer `{ value: string, text: string }[]` on its own.

The usage:
```
const lookup = NSearch.lookupFields({
            type: currentRecord.type,
            id: currentRecord.id,
            columns: "test",
        })["test"] as NSearch.LookupValueObject[]
```