### PR TITLE
xml node attributes improvement

### DIFF
--- a/N/xml.d.ts
+++ b/N/xml.d.ts
@@ -13,7 +13,7 @@ interface NSNode {
     normalize: () => void;
     removeChild: (options: RemoveChildOptions) => NSNode;
     replaceChild: (options: ReplaceChildOptions) => NSNode;
-    attributes: string;
+    attributes: { [key: string]: Attribute };
     baseURI: string;
     childNodes: NSNode[];
     firstChild: NSNode;
@@ -33,6 +33,18 @@ interface NSNode {
 
 interface AppendChildOptions {
     newChild: NSNode;
+}
+
+interface Attribute {
+    name: string;
+    ownerElement: {
+        name: string;
+        type: NodeType,
+        value: string | null,
+        textContent: string,
+    }
+    specified: boolean,
+    value: string;
 }
 
 interface CloneNodeOptions {


### PR DESCRIPTION
This PR improves typings for xml node `attributes`. Unfortunately the NS doc contains only very few information about it. We derived it from runtime.

![Snímek obrazovky 2020-11-16 v 14 32 53](https://user-images.githubusercontent.com/13610612/99258285-9fc8df80-2818-11eb-8084-a96b1987ba61.png)
