### PR TITLE
Add localizationContext interface and localizationContextEnter/Exit entry points

### DIFF
--- a/N/types.d.ts
+++ b/N/types.d.ts
@@ -166,6 +166,14 @@ export namespace EntryPoints {
         }
 
         type validateLine = (scriptContext: validateLineContext) => boolean;
+
+        interface localizationContext {
+            currentRecord: N_record.ClientCurrentRecord;
+            locale: string;
+        }
+
+        type localizationContextEnter = (scriptContext: localizationContext) => void;
+        type localizationContextExit = (scriptContext: localizationContext) => void;
     }
 
     namespace UserEvent {


### PR DESCRIPTION
Since NetSuite version 2020 Release 1 there are two new SuiteScript 2.0 Client Script entry points.
This PR adds typing support for this new entry points.
See in the NetSuite Help Center under:
SuiteCloud Platform > SuiteScript > SuiteScript 2.0 > SuiteScript 2.0 Script Types > SuiteScript 2.0 Client Script Type > SuiteScript 2.0 Client Script Entry Points and API (help/helpcenter.nl?fid=section_157495533652.html)