### PR TITLE
Update types.d.ts

### DIFF
--- a/N/types.d.ts
+++ b/N/types.d.ts
@@ -260,27 +260,34 @@ export namespace EntryPoints {
         interface MapReduceOutputIterator {
             each(callback: (key: string, value: string) => boolean): void;
         }
+        
         interface MapReduceOutputIteratorContainer {
             iterator(): MapReduceOutputIterator;
         }
+        
         interface MapReduceSummaryIterator {
             each(callback: (key: string, executionCount: number, completionState: string) => boolean): void;
         }
+        
         interface MapReduceSummaryIteratorContainer {
             iterator(): MapReduceSummaryIterator;
         }
+        
         interface MapReduceErrorIterator {
             each(callback: (key: string, error: string, executionNo: number) => boolean): void;
         }
+        
         interface MapReduceErrorIteratorContainer {
             iterator(): MapReduceErrorIterator;
         }
+        
         interface InputSummary {
             dateCreated: Date;
             error: string;
             seconds: number;
             usage: number;
         }
+        
         interface MapSummary {
             dateCreated: Date;
             seconds: number;
@@ -290,6 +297,7 @@ export namespace EntryPoints {
             keys: MapReduceSummaryIteratorContainer;
             errors: MapReduceErrorIteratorContainer;
         }
+        
         interface ReduceSummary {
             dateCreated: Date;
             seconds: number;
@@ -299,6 +307,7 @@ export namespace EntryPoints {
             keys: MapReduceSummaryIteratorContainer;
             errors: MapReduceErrorIteratorContainer;
         }
+        
         interface summarizeContext {
             readonly isRestarted: boolean;
             dateCreated: Date;
@@ -311,6 +320,7 @@ export namespace EntryPoints {
             reduceSummary: ReduceSummary;
             output: MapReduceOutputIteratorContainer;
         }
+        
         type summarize = (summary: summarizeContext) => void;
     }
 

--- a/N/types.d.ts
+++ b/N/types.d.ts
@@ -260,34 +260,34 @@ export namespace EntryPoints {
         interface MapReduceOutputIterator {
             each(callback: (key: string, value: string) => boolean): void;
         }
-        
+
         interface MapReduceOutputIteratorContainer {
             iterator(): MapReduceOutputIterator;
         }
-        
+
         interface MapReduceSummaryIterator {
             each(callback: (key: string, executionCount: number, completionState: string) => boolean): void;
         }
-        
+
         interface MapReduceSummaryIteratorContainer {
             iterator(): MapReduceSummaryIterator;
         }
-        
+
         interface MapReduceErrorIterator {
             each(callback: (key: string, error: string, executionNo: number) => boolean): void;
         }
-        
+
         interface MapReduceErrorIteratorContainer {
             iterator(): MapReduceErrorIterator;
         }
-        
+
         interface InputSummary {
             dateCreated: Date;
             error: string;
             seconds: number;
             usage: number;
         }
-        
+
         interface MapSummary {
             dateCreated: Date;
             seconds: number;
@@ -297,7 +297,7 @@ export namespace EntryPoints {
             keys: MapReduceSummaryIteratorContainer;
             errors: MapReduceErrorIteratorContainer;
         }
-        
+
         interface ReduceSummary {
             dateCreated: Date;
             seconds: number;
@@ -307,7 +307,7 @@ export namespace EntryPoints {
             keys: MapReduceSummaryIteratorContainer;
             errors: MapReduceErrorIteratorContainer;
         }
-        
+
         interface summarizeContext {
             readonly isRestarted: boolean;
             dateCreated: Date;
@@ -320,7 +320,7 @@ export namespace EntryPoints {
             reduceSummary: ReduceSummary;
             output: MapReduceOutputIteratorContainer;
         }
-        
+
         type summarize = (summary: summarizeContext) => void;
     }
 

--- a/N/types.d.ts
+++ b/N/types.d.ts
@@ -257,49 +257,48 @@ export namespace EntryPoints {
 
         type reduce = (scriptContext: reduceContext) => void;
 
-        interface MapReduceIterator {
+        interface MapReduceOutputIterator {
+            each(callback: (key: string, value: string) => boolean): void;
+        }
+        interface MapReduceOutputIteratorContainer {
+            iterator(): MapReduceOutputIterator;
+        }
+        interface MapReduceSummaryIterator {
             each(callback: (key: string, executionCount: number, completionState: string) => boolean): void;
         }
-
-        interface MapReduceIteratorContainer {
-            iterator(): MapReduceIterator;
+        interface MapReduceSummaryIteratorContainer {
+            iterator(): MapReduceSummaryIterator;
         }
-
         interface MapReduceErrorIterator {
             each(callback: (key: string, error: string, executionNo: number) => boolean): void;
         }
-
         interface MapReduceErrorIteratorContainer {
             iterator(): MapReduceErrorIterator;
         }
-
         interface InputSummary {
             dateCreated: Date;
             error: string;
             seconds: number;
             usage: number;
         }
-
         interface MapSummary {
             dateCreated: Date;
             seconds: number;
             usage: number;
             concurrency: number;
             yields: number;
-            keys: MapReduceIteratorContainer;
+            keys: MapReduceSummaryIteratorContainer;
             errors: MapReduceErrorIteratorContainer;
         }
-
         interface ReduceSummary {
             dateCreated: Date;
             seconds: number;
             usage: number;
             concurrency: number;
             yields: number;
-            keys: MapReduceIteratorContainer;
+            keys: MapReduceSummaryIteratorContainer;
             errors: MapReduceErrorIteratorContainer;
         }
-
         interface summarizeContext {
             readonly isRestarted: boolean;
             dateCreated: Date;
@@ -310,9 +309,8 @@ export namespace EntryPoints {
             inputSummary: InputSummary;
             mapSummary: MapSummary;
             reduceSummary: ReduceSummary;
-            output: MapReduceIteratorContainer;
+            output: MapReduceOutputIteratorContainer;
         }
-
         type summarize = (summary: summarizeContext) => void;
     }
 


### PR DESCRIPTION
Divided the MapReduceIteratorContainer into two: MapRecudeOutputIteratorContainer and MapRecudeSummaryIteratorContainer as they have different parameters