### PR TITLE
Add nodisplay to FieldDisplayType enum

### DIFF
--- a/N/ui/serverWidget.d.ts
+++ b/N/ui/serverWidget.d.ts
@@ -562,6 +562,7 @@ export enum FieldDisplayType {
     INLINE,
     NORMAL,
     READONLY,
+    NODISPLAY,
 }
 
 export enum FieldLayoutType {

--- a/N/ui/serverWidget.d.ts
+++ b/N/ui/serverWidget.d.ts
@@ -560,9 +560,9 @@ export enum FieldDisplayType {
     ENTRY,
     HIDDEN,
     INLINE,
+    NODISPLAY,
     NORMAL,
     READONLY,
-    NODISPLAY,
 }
 
 export enum FieldLayoutType {


### PR DESCRIPTION
Allows to set field display types to 'nodisplay' - The field is not displayed on the form but can be made visible (for example, by an attached client script upon a field change).