### PR TITLE
Add savesubmit enum to UserEventTypes

### DIFF
--- a/N/types.d.ts
+++ b/N/types.d.ts
@@ -35,6 +35,7 @@ declare enum UserEventType {
     QUICKVIEW,
     REASSIGN,
     REJECT,
+    SAVESUBMIT,
     SHIP,
     SPECIALORDER,
     TRANSFORM,
@@ -61,6 +62,7 @@ declare interface UserEventTypes {
     QUICKVIEW: UserEventType;
     REASSIGN: UserEventType;
     REJECT: UserEventType;
+    SAVESUBMIT: UserEventType;
     SHIP: UserEventType;
     SPECIALORDER: UserEventType;
     TRANSFORM: UserEventType;


### PR DESCRIPTION
This is a weird UserEventType that isn't documented within NetSuite but does exist on the Weekly Timesheet record/context - may exist on others that require a record to be submitted for approval (i.e expenses/purchase requests) but I haven't tested them.

I found this out by logging out the entire 'context' within an afterSubmit entrypoint applied to the 'Timesheet' record type and submitting a timesheet for approval.
