### PR TITLE
Adding CreateColumnWithFormulaOptions to Query.createColumn

### DIFF
--- a/N/query.d.ts
+++ b/N/query.d.ts
@@ -313,7 +313,7 @@ export interface Query {
      * Create a Column object based on the root component of the Query. This is a shortcut for Query.root.createColumn.
      * @see Component.createColumn
      */
-    createColumn(options: CreateColumnOptions): Column;
+    createColumn(options: CreateColumnOptions | CreateColumnWithFormulaOptions): Column;
 
     /**
      * Create a Sort object based on the root component of the Query. This is a shortcut for Query.root.createSort.


### PR DESCRIPTION
It is currently not possible to add a column using formula with the `Query.createColumn` method.
A workaround is to use `query.root.createColumn`, since the Component's `createColumn` has the CreateColumnWithFormulaOptions type in the union.