### PR TITLE
Fix return type of ClientCurrentRecord.insertLine

### DIFF
--- a/N/record.d.ts
+++ b/N/record.d.ts
@@ -526,7 +526,7 @@ export interface ClientCurrentRecord {
     /** The internal ID of a specific record. */
     id: number;
     /** Inserts a sublist line. */
-    insertLine(options: InsertLineOptions): ClientCurrentRecord; // Issue #132
+    insertLine(options: InsertLineOptions): this; // Issue #132
     /**
      * Indicates whether the record is in dynamic or standard mode.
      * - If set to true, the record is currently in dynamic mode. If set to false, the record is currently in standard mode.


### PR DESCRIPTION
It should return `this` so subtypes (like `Record`) behave properly.