### PR TITLE
Fix n/query Iterator signature

### DIFF
--- a/N/query.d.ts
+++ b/N/query.d.ts
@@ -749,7 +749,7 @@ interface Period {
 }
 
 export interface Iterator {
-    each(f: (result: Result) => boolean): void;
+    each(f: (result: { value: Result }) => boolean): void;
 }
 
 interface PageIterator {


### PR DESCRIPTION
the iterator's .each returns an object with key .value, as per https://system.netsuite.com/app/help/helpcenter.nl?fid=section_0831085754.html