### PR TITLE
Adding properties of a record for use in client scripts to determine if the record is being created.

### DIFF
--- a/N/record.d.ts
+++ b/N/record.d.ts
@@ -578,12 +578,12 @@ export interface ClientCurrentRecord {
      * This value read is true when the record is being created
      * This property is read-only.
      */
-    isNew: boolean;
+    readonly isNew: boolean;
     /**
      * Returns true if the record form cannot be edited, or false otherwise.
      * This property is read-only.
      */
-    isReadOnly: boolean;
+    readonly isReadOnly: boolean;
     /**
      * Moves one line of the sublist to another location. The sublist machine must allow moving lines, for example: editmachine.setAllowMoveLines(true);.
      * The sublist must contain the _sequence field. The sublist type must be edit machine. When using this method, the order of the other lines is preserved.

--- a/N/record.d.ts
+++ b/N/record.d.ts
@@ -574,11 +574,11 @@ export interface ClientCurrentRecord {
      * This value is set when the record is created or accessed.
      */
     isDynamic: boolean;
-	/**
-	 * This value read is true when the record is being created
+    /**
+     * This value read is true when the record is being created
      * This property is read-only.
-	 */
-	isNew: boolean;	
+     */
+    isNew: boolean;
     /**
      * Returns true if the record form cannot be edited, or false otherwise.
      * This property is read-only.
@@ -626,7 +626,7 @@ export interface ClientCurrentRecord {
     /** Sets the value of a field. */
     setValue(options: SetValueOptions): this;
     setValue(fieldId: string, value: FieldValue): this;
-    
+
     /** The record type. */
     type: Type | string;
 }

--- a/N/record.d.ts
+++ b/N/record.d.ts
@@ -574,6 +574,16 @@ export interface ClientCurrentRecord {
      * This value is set when the record is created or accessed.
      */
     isDynamic: boolean;
+	/**
+	 * This value read is true when the record is being created
+     * This property is read-only.
+	 */
+	isNew: boolean;	
+    /**
+     * Returns true if the record form cannot be edited, or false otherwise.
+     * This property is read-only.
+     */
+    isReadOnly: boolean;
     /**
      * Moves one line of the sublist to another location. The sublist machine must allow moving lines, for example: editmachine.setAllowMoveLines(true);.
      * The sublist must contain the _sequence field. The sublist type must be edit machine. When using this method, the order of the other lines is preserved.

--- a/N/record.d.ts
+++ b/N/record.d.ts
@@ -576,12 +576,10 @@ export interface ClientCurrentRecord {
     isDynamic: boolean;
     /**
      * This value read is true when the record is being created
-     * This property is read-only.
      */
     readonly isNew: boolean;
     /**
      * Returns true if the record form cannot be edited, or false otherwise.
-     * This property is read-only.
      */
     readonly isReadOnly: boolean;
     /**


### PR DESCRIPTION
The isNew and isReadOnly are useful for quick checks in the Client Script on a CurrentRecord. Confirmed this is working in our sandbox instance.

Checked against Inventory Transfer record, both creation and one that was already created.

Also confirmed the following to work around CI/CD issue with this not being in the library yes
```
        interface extendeCurRec extends record.ClientCurrentRecord { isNew?: boolean };
        const extCurRec: extendeCurRec = context.currentRecord;
        
        if (extCurRec.isNew) {
          ...
        }
```