### PR TITLE
render.d.ts

### DIFF
--- a/N/render.d.ts
+++ b/N/render.d.ts
@@ -130,14 +130,16 @@ interface TemplateRenderer {
     renderAsPdf(): File;
     /** Renders a server response into a PDF file. For example, you can pass in a response to be rendered as a PDF in a browser, or downloaded by a user. */
     renderPdfToResponse(options: RenderToResponseOptions): void;
+    renderPdfToResponse(serverResponse: ServerResponse): void;
     /** Return template content in string form. */
     renderAsString(): string;
     /** Writes template content to a server response. */
     renderToResponse(options: RenderToResponseOptions): void;
+    renderToResponse(serverResponse: ServerResponse): void;
     /** Sets the template using the internal ID. */
     setTemplateById(options: { id: number; }): void;
     /** Sets the template using the script ID. */
-    setTemplateByScriptId(options: { scriptId: string; }): void;
+    setTemplateByScriptId(options: { scriptId: Uppercase<string>; }): void;
     /** Content of template. */
     templateContent: string;
 }


### PR DESCRIPTION
Hi !

I noticed that when I used renderPdfToResponse with the RenderToResponseOptions options, printing failed. I tried with a ServerResponse parameter and it worked (it also worked with renderToResponse). I can only find the RenderToResponseOptions in the documentation but, for me, it must be a typo for renderPdfToResponse, and, in both case, the other way of transmitting the response can be useful.
Using an Uppercase type on the setTemplateByScriptId method would be nice because it seems that this method does not work with lower case script IDs.

Have a nice day !