### PR TITLE
Exporting a type that is returned in things like asMappedResult for use in the iterator

### DIFF
--- a/N/query.d.ts
+++ b/N/query.d.ts
@@ -602,7 +602,7 @@ export interface Condition {
     readonly component: Component;
 }
 
-type QueryResultMap = { [fieldId: string]: string | boolean | number | null }
+export type QueryResultMap = { [fieldId: string]: string | boolean | number | null }
 /**
  * Set of results returned by the query.
  */


### PR DESCRIPTION
PR to address this issue: https://github.com/headintheclouddev/typings-suitescript-2.0/issues/256