### PR TITLE
Added the export keyword in front of the IEmail interface

### DIFF
--- a/EmailCapturePlugin.d.ts
+++ b/EmailCapturePlugin.d.ts
@@ -1,6 +1,6 @@
 interface IAddress {
   getEmail(): string;
-  getName():  string;
+  getName(): string;
 }
 
 interface IAttachment {
@@ -19,14 +19,14 @@ interface IAttachment {
 }
 
 /** Object that represents an email message sent to the Email Capture plug-in implementation. */
-interface IEmail {
+export interface IEmail {
   getAttachments(): IAttachment[];
-  getCc():          IAddress;
-  getFrom():        IAddress[];
-  getHtmlBody():    string;
-  getReplyTo():     IAddress;
-  getSentDate():    Date;
-  getSubject():     string;
-  getTextBody():    string;
-  getTo():          IAddress;
+  getCc(): IAddress;
+  getFrom(): IAddress[];
+  getHtmlBody(): string;
+  getReplyTo(): IAddress;
+  getSentDate(): Date;
+  getSubject(): string;
+  getTextBody(): string;
+  getTo(): IAddress;
 }


### PR DESCRIPTION
I had problems using the EmailCapturePlugin so I have added the export keyword and imported it like this
`import { IEmail } from "@hitc/netsuite-types/EmailCapturePlugin";
`
This is my first pull request ever and I am fairly new to TypeScript, any feedback or guidance on best practices would be greatly appreciated. Thank you for creating this project!