### PR TITLE
Added SearchTask.inboundDependencies

### DIFF
--- a/N/task.d.ts
+++ b/N/task.d.ts
@@ -146,6 +146,7 @@ interface SearchTask {
     savedSearchId: number;
     fileId: number;
     filePath: string;
+    inboundDependencies: Record<string, Readonly<{id?: string; type: string; scriptId: string; deploymentId: string; params: any}>>;
 }
 
 interface SearchTaskStatus {


### PR DESCRIPTION
Key/value pairs that contain information about the dependent scripts added to the search task. Use this property to verify the properties of dependent scripts after you add the scripts using SearchTask.addInboundDependency().

See https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_1530715682.html#SearchTask.inboundDependencies