### PR TITLE
Update task.d.ts

### DIFF
--- a/N/task.d.ts
+++ b/N/task.d.ts
@@ -111,7 +111,7 @@ interface SuiteQLTask {
 
 interface SearchTaskCreateOptions {
     taskType: TaskType.SEARCH
-    savedSearchId?: number;
+    savedSearchId?: number | string;
     fileId?: number;
     filePath?: string;
 }


### PR DESCRIPTION
Undocumented feature of the search task is that you can send in the id as the savedSearchId.  (ie. 'customsearch_cash_acts' instead of 123)