### PR TITLE
Export PageIterator so we can refer to it as a type from other scripts

### DIFF
--- a/N/query.d.ts
+++ b/N/query.d.ts
@@ -757,7 +757,7 @@ export interface Iterator {
     each(f: (result: { value: Result }) => boolean): void;
 }
 
-interface PageIterator {
+export interface PageIterator {
     each(f: (result: { value: Page }) => boolean): void;
 }
 


### PR DESCRIPTION
Tried to declare a variable of type PageIterator but needed it to be exposed.