### PR TITLE
add missing File.Type enum keys

### DIFF
--- a/N/file.d.ts
+++ b/N/file.d.ts
@@ -133,8 +133,11 @@ export enum Encoding {
 
 /** Enumeration that holds the string values for supported file types. */
 export enum Type {
+    APPCACHE,
     AUTOCAD,
     BMPIMAGE,
+    CERTIFICATE,
+    CONFIG,
     CSV,
     EXCEL,
     FLASH,
@@ -158,8 +161,10 @@ export enum Type {
     POWERPOINT,
     QUICKTIME,
     RTF,
+    SCSS,
     SMS,
     STYLESHEET,
+    SVG,
     TAR,
     TIFFIMAGE,
     VISIO,


### PR DESCRIPTION
Adds a small handful of keys that are missing from File.Type, per #288

To double-check, I based changes off the documentation here: https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_4228999954.html