### PR TITLE
Omit subrecord.save() in places where it will throw a "method does not exist" error

### DIFF
--- a/N/record.d.ts
+++ b/N/record.d.ts
@@ -547,7 +547,7 @@ export interface ClientCurrentRecord {
     getSublistValue(options: GetSublistValueOptions): FieldValue;
     getSublistValue(sublistId: string, fieldId: string, line: number): FieldValue;
     /** Gets the subrecord for the associated field. */
-    getSubrecord(options: GetFieldOptions): Record;
+    getSubrecord(options: GetFieldOptions): Omit<Record, "save">;
     /** Returns the text representation of a field value. */
     getText(options: GetFieldOptions): string | string[];
     getText(fieldId: string): string | string[];
@@ -634,7 +634,7 @@ export interface Record extends ClientCurrentRecord {
     /** Returns all the field names in a sublist. */
     getSublistFields(options: RecordGetLineCountOptions): string[];
     /** Gets the subrecord associated with a sublist field. */
-    getSublistSubrecord(options: GetSublistValueOptions): Record;
+    getSublistSubrecord(options: GetSublistValueOptions): Omit<Record, "save">;
     /**
      * Removes the subrecord for the associated sublist field.
      * @restriction only available in deferred dynamic record


### PR DESCRIPTION
This is a small change that omits the `.save()` method from subrecords returned from `record.getSubrecord()` and `record.getSublistSubrecord()` - in each case, attempting to "save" the subrecord prior to its main record throws `sublistSubrecord.save is not a function` once deployed.

This is a small detail, but actually quite a big footgun - it's easy to intuitively assume you'd need to .save() the subrecord before the main record (this is, in fact, how I found this to begin with 😅)