### PR TITLE
Add optional body field schema generic to N/record method types

### DIFF
--- a/example-Record-generics.ts
+++ b/example-Record-generics.ts
@@ -21,7 +21,7 @@ interface BillFieldSchema extends RecordFieldSchema {
  * Types are also inferred for "setValue", helping ensure you are using the type any given
  * field id expects.
  */
-function withFieldsMapGeneric() {
+function withFieldSchema() {
     const bill = loadRecord<BillFieldSchema>({
         type: RecordType.VENDOR_BILL,
         id: 1,
@@ -44,7 +44,7 @@ function withFieldsMapGeneric() {
  * Not passing a generic will mean getValue returns a FieldValue, requiring you to cast the
  * value to use type-specific methods (This is the same behavior as before record maps were implemented).
  */
-function withoutFieldsMapGeneric() {
+function withoutFieldSchema() {
     const bill = loadRecord({
         type: RecordType.VENDOR_BILL,
         id: 1,
@@ -65,6 +65,6 @@ function withoutFieldsMapGeneric() {
 }
 
 export const pageInit: EntryPoints.Client.pageInit = (_context) => {
-    withFieldsMapGeneric();
-    withoutFieldsMapGeneric();
+    withFieldSchema();
+    withoutFieldSchema();
 };

--- a/example-Record-generics.ts
+++ b/example-Record-generics.ts
@@ -1,0 +1,60 @@
+/**
+ * @NAPIVersion 2.1
+ * @NScriptType ClientScript
+ */
+
+import { EntryPoints } from "N/types";
+import { load as loadRecord, Type as RecordType, RecordFieldsMap } from "N/record";
+
+type InternalId = `${number}`;
+
+interface BillFieldsMap extends RecordFieldsMap {
+    tranid: string;
+    subsidiary: InternalId;
+    trandate: Date;
+}
+
+/**
+ * By passing a generic to "load record" that maps each field ID to its JavaScript return type,
+ * types are now inferred automatically when using "getValue".
+ */
+function withFieldsMapGeneric() {
+    const bill = loadRecord<BillFieldsMap>({
+        type: RecordType.VENDOR_BILL,
+        id: 1,
+    });
+    const billTranId = bill.getValue("tranid");
+    const billDate = bill.getValue("trandate");
+    const billUnmapped = bill.getValue("unmapped");
+
+    /* No error! */
+    billTranId.split("0");
+    billDate.getUTCMilliseconds();
+    billUnmapped.toString();
+}
+
+/**
+ * Not passing a generic will mean getValue returns a FieldValue, requiring you to cast the
+ * value to use type-specific methods (This is the same behavior as before record maps were implemented).
+ */
+function withoutFieldsMapGeneric() {
+    const bill = loadRecord({
+        type: RecordType.VENDOR_BILL,
+        id: 1,
+    });
+    const billTranId = bill.getValue("tranid");
+    const billDate = bill.getValue("trandate");
+    const billUnmapped = bill.getValue("unmapped");
+
+    // /* This line would now cause a compile-time error: */
+    // billDate.getUTCMilliseconds();  # Property 'getUTCMilliseconds' does not exist on type 'FieldValue'. Property 'getUTCMilliseconds' does not exist on type 'string'.
+
+    (billTranId as InternalId).split("0");
+    (billDate as Date).getUTCMilliseconds();
+    billUnmapped.toString();
+}
+
+export const pageInit: EntryPoints.Client.pageInit = (_context) => {
+    withFieldsMapGeneric();
+    withoutFieldsMapGeneric();
+};

--- a/example-Record-generics.ts
+++ b/example-Record-generics.ts
@@ -4,22 +4,25 @@
  */
 
 import { EntryPoints } from "N/types";
-import { load as loadRecord, Type as RecordType, RecordFieldsMap } from "N/record";
+import { load as loadRecord, Type as RecordType, RecordFieldSchema } from "N/record";
 
 type InternalId = `${number}`;
 
-interface BillFieldsMap extends RecordFieldsMap {
+interface BillFieldSchema extends RecordFieldSchema {
     tranid: string;
-    subsidiary: InternalId;
     trandate: Date;
+    subsidiary: InternalId;
 }
 
 /**
  * By passing a generic to "load record" that maps each field ID to its JavaScript return type,
  * types are now inferred automatically when using "getValue".
+ *
+ * Types are also inferred for "setValue", helping ensure you are using the type any given
+ * field id expects.
  */
 function withFieldsMapGeneric() {
-    const bill = loadRecord<BillFieldsMap>({
+    const bill = loadRecord<BillFieldSchema>({
         type: RecordType.VENDOR_BILL,
         id: 1,
     });
@@ -31,6 +34,10 @@ function withFieldsMapGeneric() {
     billTranId.split("0");
     billDate.getUTCMilliseconds();
     billUnmapped.toString();
+
+    /* This line will cause compile-time error, instead of one at runtime: */
+    // bill.setValue("subsidiary", "NaN");  # Argument of type '"NaN"' is not assignable to parameter of type '`${number}`'.
+    bill.setValue("subsidiary", "3");
 }
 
 /**
@@ -49,9 +56,12 @@ function withoutFieldsMapGeneric() {
     // /* This line would now cause a compile-time error: */
     // billDate.getUTCMilliseconds();  # Property 'getUTCMilliseconds' does not exist on type 'FieldValue'. Property 'getUTCMilliseconds' does not exist on type 'string'.
 
-    (billTranId as InternalId).split("0");
+    (billTranId as string).split("0");
     (billDate as Date).getUTCMilliseconds();
     billUnmapped.toString();
+
+    /* This line does not cause a compile-time error, meaning this bug will only surface at runtime: */
+    bill.setValue("subsidiary", "NaN");
 }
 
 export const pageInit: EntryPoints.Client.pageInit = (_context) => {


### PR DESCRIPTION
As it is now, `record.getValue()` always returns the `FieldValue` union type, and `record.setValue()` accepts a `FieldValue` union type. This often requires type casting each time you `getValue()` and need to use it as a specific type. `setValue` has a (slightly) more dangerous problem: you can set a field to the wrong type and you'll only find out at runtime, removing some of the benefit of using types to begin with.

These changes aim to add optional generics - that is, without causing breaking changes - to allow users to pass a single custom "schema" type that maps NetSuite field IDs to their JavaScript types, allowing for type inference to detect improper field types at compile time. The user still needs to know the correct types of each field, but they now only need to define those relationships in one place.

At least one downside is that method signatures are uglier and less intuitive, so I'm open to feedback and discussion. Sublist and subrecord methods haven't been handled yet, so this only targets a record's body fields, for now. A new example-Record-generics.ts is included to demonstrate usage.