### PR TITLE
Corrected type definitions in Client interfaces

### DIFF
--- a/N/types.d.ts
+++ b/N/types.d.ts
@@ -93,10 +93,10 @@ export namespace EntryPoints {
     namespace Client {
         interface fieldChangedContext {
             currentRecord: N_record.ClientCurrentRecord;
-            sublistId: string;
+            sublistId?: string;
             fieldId: string;
-            line: number;
-            column: number;
+            line?: number;
+            column?: number;
         }
 
         type fieldChanged = (scriptContext: fieldChangedContext) => void;
@@ -117,7 +117,7 @@ export namespace EntryPoints {
 
         interface postSourcingContext {
             currentRecord: N_record.ClientCurrentRecord;
-            sublistId: string;
+            sublistId?: string;
             fieldId: string;
         }
 
@@ -150,7 +150,7 @@ export namespace EntryPoints {
 
         interface validateFieldContext {
             currentRecord: N_record.ClientCurrentRecord;
-            sublistId: string|null;
+            sublistId?: string;
             fieldId: string;
             line?: number;
             column?: number;

--- a/N/types.d.ts
+++ b/N/types.d.ts
@@ -93,7 +93,7 @@ export namespace EntryPoints {
     namespace Client {
         interface fieldChangedContext {
             currentRecord: N_record.ClientCurrentRecord;
-            sublistId?: string;
+            sublistId: string | null;
             fieldId: string;
             line?: number;
             column?: number;


### PR DESCRIPTION
Made sublistId, line, and column properties optional in several Client interface contexts. While the documentation doesn't call these out directly, its known that header field do not send sublist values.