### PR TITLE
Add Column and Filter `toString` and `toJSON` methods

### DIFF
--- a/N/search.d.ts
+++ b/N/search.d.ts
@@ -25,6 +25,21 @@ export interface Filter {
     readonly summary: Summary;
     /** Formula used by the search filter. Use this property to get or set the formula used by the search filter. */
     formula: string;
+    /** Returns the object type name */
+    toString(): string;
+    /** Get JSON format of the object */
+    toJSON(): {
+        name: string;
+        join: string | null | undefined;
+        operator: keyof typeof Operator;
+        summary: keyof typeof Summary | null | undefined;
+        formula: string | null | undefined;
+        values: string[];
+        isor: boolean;
+        isnot: boolean;
+        leftparens: number;
+        rightparens: number;
+    };
 }
 
 interface SearchColumnSetWhenOrderedByOptions {
@@ -52,6 +67,22 @@ export interface Column {
     function?: string
     /** The sort order of the column. Use the search.Sort enum to set the value. */
     sort?: Sort;
+    /** Returns the object type name */
+    toString(): string;
+    /** Get JSON format of the object */
+    toJSON(): {
+        name: string;
+        join: string | null | undefined;
+        summary: keyof typeof Summary | null | undefined;
+        label: string | null;
+        type: string | null;
+        formula: string | null | undefined;
+        function: string | null | undefined;
+        sortdir: keyof typeof Sort;
+        whenorderedby: string | null | undefined;
+        whenorderedbyjoin: string | null | undefined;
+        whenorderedbyalias: string | null | undefined;
+    };
 }
 
 export interface Result {


### PR DESCRIPTION
Both the `Column` and `Filter` objects have `toString` and `toJSON` methods.
These methods aren't in the docs but according to the NetSuite client code, these methods have existed since 2018.1 for `Column` and 2015.2 for `Filter`.