### PR TITLE
N/query: Add bigint as a possible query result value type

### DIFF
--- a/N/query.d.ts
+++ b/N/query.d.ts
@@ -602,7 +602,7 @@ export interface Condition {
     readonly component: Component;
 }
 
-export type QueryResultMap = { [fieldId: string]: string | boolean | number | null }
+export type QueryResultMap = { [fieldId: string]: string | boolean | number | bigint | null }
 /**
  * Set of results returned by the query.
  */

--- a/N/query.d.ts
+++ b/N/query.d.ts
@@ -602,7 +602,8 @@ export interface Condition {
     readonly component: Component;
 }
 
-export type QueryResultMap = { [fieldId: string]: string | boolean | number | bigint | null }
+export type QueryResultValue = string | boolean | number | bigint | null;
+export type QueryResultMap = { [fieldId: string]: QueryResultValue };
 /**
  * Set of results returned by the query.
  */
@@ -648,7 +649,7 @@ export interface Result {
      * the array exactly matches the ResultSet.types, ResultSet.columns or Result.columns property.
      * @throws {SuiteScriptError} READ_ONLY when setting the property is attempted
      */
-    readonly values: Array<boolean | string | number | null>;
+    readonly values: Array<QueryResultValue>;
 
     /**
      * The return columns. This is equivalent to ResultSet.columns.


### PR DESCRIPTION
Ran into a nasty bug caused by unexpected `BigInt`s appearing when querying an Integer Number type custom field. Specifically, `ResultSet.asMappedResults()` was returning some values as `BigInt` when they are large enough, which is supposedly impossible based on the types listed in this package, but is (perhaps more importantly) undocumented in Oracle's documentation as well (there, the possible types of a result value are `<string | number | | null>` at the time of writing, which is obviously wrong!).

In hindsight, it makes sense that this happens, since the maximum possible integer value that can be stored in an integer field is much larger than `MAX_SAFE_INTEGER`, but it still can cause quite a headache.

Any `BigInt` property returned in an object from a RESTlet endpoint will cause an uncatchable, very-difficult-to-debug UNEXPECTED_ERROR that occurs after the endpoint function has already successfully returned (due to, presumably, `JSON.stringify()` being unable to serialize the `BigInt`), which this PR does nothing to fix, but at least it may help point people facing this problem in the right direction, and clearly outlines that this type needs to be explicitly handled in general.