### PR TITLE
Introduce Generics to RESTlet operations

### DIFF
--- a/N/types.d.ts
+++ b/N/types.d.ts
@@ -373,10 +373,10 @@ export namespace EntryPoints {
     }
 
     namespace RESTlet {
-        type get = (requestParameters: {[key: string]: any}) => {[key: string]: any} | string;
-        type delete_ = (requestParameters: {[key: string]: any}) => {[key: string]: any} | string;
-        type post = (requestBody: {[key: string]: any} | string) => {[key: string]: any} | string;
-        type put = (requestBody: {[key: string]: any} | string) => {[key: string]: any} | string;
+        type get<T = unknown, Y = string> = (requestParams: T) => Y;
+        type delete_<T = unknown, Y = string> = (requestParams: T) => Y;
+        type post<T = unknown, Y = string> = (requestBody: T | string) => Y;
+        type put<T = unknown, Y = string> = (requestBody: T | string) => Y;
     }
 
     namespace BundleInstallation {


### PR DESCRIPTION
Refactor RESTlet type definitions for better flexibility

Introduced generic types `T` and `Y` to RESTlet methods for improved typing flexibility and clarity. This changes the method definitions to support more customizable input and output types, enhancing reusability and type safety.

This allows ensures that developers are returning something from the put/post operations