### PR TITLE
getCurrentSublistText alternative signature added.

### DIFF
--- a/N/record.d.ts
+++ b/N/record.d.ts
@@ -503,6 +503,7 @@ export interface ClientCurrentRecord {
     getCurrentSublistSubrecord(options: GetCurrentSublistValueOptions): Record;
     /** Returns a text representation of the field value in the currently selected line. */
     getCurrentSublistText(options: GetCurrentSublistValueOptions): string;
+    getCurrentSublistText(sublistId: string, fieldId: string): string;
     /** Returns the value of a sublist field on the currently selected sublist line. */
     getCurrentSublistValue(options: GetCurrentSublistValueOptions): FieldValue;
     getCurrentSublistValue(sublistId: string, fieldId: string): FieldValue;


### PR DESCRIPTION
Alternative signature for `getCurrentSublistText` added. Confirmed working in console:

```ts
require("N/record");
record = require("N/record");
rec = record.load({ type: "customer", id: -1, isDynamic: true });
rec.selectLine({ sublistId: "paymentinstruments", line: 0 });
rec.getCurrentSublistText("paymentinstruments", "mask");
```