### PR TITLE
Update record type

### DIFF
--- a/N/record.d.ts
+++ b/N/record.d.ts
@@ -629,7 +629,7 @@ export interface ClientCurrentRecord {
     setValue(fieldId: string, value: FieldValue): this;
 
     /** The record type. */
-    type: Type | string;
+    readonly type: Type | `${Type}`;
 }
 
 // Exported for other modules to be able to consume this type


### PR DESCRIPTION
- Made property readonly to prevent attempting to set this value
- Updated type definition to narrow `string` to actual values from the Type enum