### PR TITLE
Workbook createSimpleRecordKey function signature

### DIFF
--- a/N/workbook.d.ts
+++ b/N/workbook.d.ts
@@ -1041,7 +1041,7 @@ export function createTableColumnFilter(options: CreateTableColumnFilter): Table
 /**
 * Creates a record key.
 */
-export function createSimpleRecordKey({ key: number }): number;
+export function createSimpleRecordKey(options: { key: number }): number;
 
 /**
  * Lists all existing workbooks.


### PR DESCRIPTION
The signature of `createSimpleRecordKey` function was attempting to destructure an object that did not exist.