### PR TITLE
Make `oldRecord` optional in event contexts

### DIFF
--- a/N/types.d.ts
+++ b/N/types.d.ts
@@ -194,7 +194,7 @@ export namespace EntryPoints {
 
         interface beforeSubmitContext {
             newRecord: N_record.Record;
-            oldRecord: N_record.Record;
+            oldRecord?: N_record.Record;
             type: UserEventType;
             UserEventType: UserEventTypes;
         }
@@ -203,7 +203,7 @@ export namespace EntryPoints {
 
         interface afterSubmitContext {
             newRecord: N_record.Record & { id: number };
-            oldRecord: N_record.Record;
+            oldRecord?: N_record.Record;
             type: UserEventType;
             UserEventType: UserEventTypes;
         }
@@ -364,7 +364,7 @@ export namespace EntryPoints {
     namespace WorkflowAction {
         interface onActionContext {
             newRecord: N_record.Record;
-            oldRecord: N_record.Record;
+            oldRecord?: N_record.Record;
             form?: N_ui_serverWidget.Form;
             type?: string;
             workflowId?: number;


### PR DESCRIPTION
Updated `oldRecord` to be optional (`?`) in `beforeSubmitContext`, `afterSubmitContext`, and `onActionContext` interfaces. This change better reflects scenarios where an old record might not exist, ensuring type safety and preventing potential runtime errors.