### PR TITLE
fix: update RecordToJSONReturnValue

### DIFF
--- a/N/record.d.ts
+++ b/N/record.d.ts
@@ -669,7 +669,7 @@ export type RecordToJSONReturnValue = {
     type: string,
     isDynamic: boolean,
     fields: {[fieldId: string]: string}
-    sublists: {[sublistId: string]: {[lineDescription: string]: string}}
+    sublists: {[sublistId: string]: {[lineDescription: string]: {[fieldId: string]: string}}}
 }
 
 interface ExecuteMacroFunction {


### PR DESCRIPTION
In `RecordToJSONReturnValue` the `sublists` property contains lines which contain fields. Fields have a key/value.

The current type results in the line having a value rather than the line being an object of fields with keys/values. This change fixes that.