### PR TITLE
not sure how this has slipped through the cracks for so long, but it'…

### DIFF
--- a/N/log.d.ts
+++ b/N/log.d.ts
@@ -1,12 +1,12 @@
 interface LogOptions {
     /** String to appear in the Title column on the Execution Log tab of the script deployment. Maximum length is 99 characters. */
-    title?: string;
+    title: string;
     /**
      * You can pass any value for this parameter.
      * If the value is a JavaScript object type, JSON.stringify(obj) is called on the object before displaying the value.
      * NetSuite truncates any resulting string over 3999 characters.
      */
-    details: any;
+    details?: any;
 }
 
 interface LogFunction {


### PR DESCRIPTION
…s the title that's required and details optional, not the other way round.

https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_4430385329.html