### PR TITLE
Update format types to prefer specific overloads

### DIFF
--- a/N/format.d.ts
+++ b/N/format.d.ts
@@ -55,21 +55,21 @@ export function format(options: FormatDateTimeOptions): string | any;
 
 /**
  * Use parse to convert a string into an object, like a Date.
- * Options: value (Date|string|number), type (format.FormatType).
- */
-export function parse(options: FormatOptions): Date | string | number;
-
-/**
- * Use parse to convert a string into an object, like a Date.
  * Options: value (Date|string), type (format.FormatType), timezone (enum).
  */
-export function parse(options: FormatDateTimeOptions): Date | string | number;
+export function parse(options: FormatDateTimeOptions): Date;
 
 /**
  * Use parse to convert a string into a number.
  * Options: value (number|string), type (format.FormatType).
  */
 export function parse(options: FormatNumberOptions): number;
+
+/**
+ * Use parse to convert a string into an object, like a Date.
+ * Options: value (Date|string|number), type (format.FormatType).
+ */
+export function parse(options: FormatOptions): Date | string | number;
 
 /**
  * -enum- Holds the string values for the supported field types. 


### PR DESCRIPTION
This commit updates the parse function prototypes to better match the actual behavior of NetSuite. In particular, it ensures that the more specific `parse` overloads, such as those for `Date`, are preferred over the more general catch-all one. This means less type casting is necessary when using `parse`, e.g., the following is now only a `Date`:

``` ts
const dt = format.parse({
    value: '2026/02/18',
    type: format.Type.DATE,
});
// Before `dt` was of type `string | number | Date`; now it's just `Date`
```