### PR TITLE
Include all ts type files

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	"license": "MIT",
 	"author": "Head in the Cloud Development <gurus@headintheclouddev.com> (www.headintheclouddev.com)",
 	"files": [
-		"./N.d.ts",
+		"./*.d.ts",
 		"./N/**/*.d.ts"
 	],
 	"repository": {


### PR DESCRIPTION
PR #369 changed the package files to only include the N and N/* typescript files which means the existing *.d.ts files in the root are currently missing from the published package.

See https://www.npmjs.com/package/@hitc/netsuite-types?activeTab=code for details.
